### PR TITLE
bugfix: seek int overflow. 

### DIFF
--- a/android/phiola/src/main/java/com/github/stsaz/phiola/MainActivity.java
+++ b/android/phiola/src/main/java/com/github/stsaz/phiola/MainActivity.java
@@ -658,7 +658,7 @@ public class MainActivity extends AppCompatActivity {
 
 	/** UI event from seek bar */
 	private void seek(int percent) {
-		trackctl.seek(percent * total_dur_msec / 100);
+		trackctl.seek(total_dur_msec / 100 * percent);
 	}
 
 	private static final int


### PR DESCRIPTION
eg, 600 minutes audio, seek to 60%, int overflow to negative value( 600*60000= 36,000,000 * 100= 3,600,000,000 > 2,147,483,648  )